### PR TITLE
[CD] Use zod Schemas as Validators & Type Definitions

### DIFF
--- a/packages/server/src/infrastructure/drizzle-data-service/repositories/transaction.repository.ts
+++ b/packages/server/src/infrastructure/drizzle-data-service/repositories/transaction.repository.ts
@@ -3,25 +3,11 @@ import {
   type TransactionDto,
   type TransactionCreateDto,
   type TransactionUpdateDto,
-  TransactionTypeEnum,
-  IncomeCategoryEnum,
-  ExpenseCategoryEnum,
+  TransactionDtoSchema,
 } from "@budgeteer/types"
 import { db } from ".."
 import { transactionsTable, type InsertTransaction, type SelectTransaction } from "../models/transaction.model"
 import { eq } from "drizzle-orm"
-import { z } from "zod"
-
-const validateTransactionSchema = z.object({
-  id: z.number(),
-  userId: z.number(),
-  description: z.string(),
-  type: z.nativeEnum(TransactionTypeEnum),
-  category: z.union([z.nativeEnum(IncomeCategoryEnum), z.nativeEnum(ExpenseCategoryEnum)]),
-  amount: z.number(),
-  createdAt: z.union([z.date(), z.string()]),
-  updatedAt: z.union([z.date(), z.string()]),
-})
 
 export const transactionRepository: ITransactionRepository = {
   async findById(id: number): Promise<TransactionDto | null> {
@@ -76,7 +62,7 @@ export const transactionRepository: ITransactionRepository = {
     await db.delete(transactionsTable).where(eq(transactionsTable.id, id))
   },
   convertToDto(data: unknown): TransactionDto {
-    const transactionData = validateTransactionSchema.parse(data)
+    const transactionData = TransactionDtoSchema.parse(data)
 
     return {
       id: transactionData.id,
@@ -85,8 +71,8 @@ export const transactionRepository: ITransactionRepository = {
       type: transactionData.type,
       amount: transactionData.amount,
       category: transactionData.category,
-      createdAt: new Date(transactionData.createdAt),
-      updatedAt: new Date(transactionData.updatedAt),
+      createdAt: transactionData.createdAt,
+      updatedAt: transactionData.updatedAt,
     }
   },
 }

--- a/packages/server/src/infrastructure/drizzle-data-service/repositories/user.repository.ts
+++ b/packages/server/src/infrastructure/drizzle-data-service/repositories/user.repository.ts
@@ -1,16 +1,13 @@
-import type { IUserRepository, UserCreateDto, UserUpdateDto, UserDto } from "@budgeteer/types"
+import {
+  type IUserRepository,
+  type UserCreateDto,
+  type UserUpdateDto,
+  type UserDto,
+  UserDtoSchema,
+} from "@budgeteer/types"
 import { db } from ".."
 import { eq } from "drizzle-orm"
 import { usersTable, type SelectUser } from "../models/user.model"
-import { z } from "zod"
-
-const validateUserSchema = z.object({
-  id: z.number(),
-  username: z.string(),
-  password: z.string(),
-  profile_picture: z.string(),
-  createdAt: z.union([z.string(), z.date()]),
-})
 
 export const userRepository: IUserRepository = {
   async findById(id: number): Promise<UserDto | null> {
@@ -52,7 +49,7 @@ export const userRepository: IUserRepository = {
     return this.convertToDto(record)
   },
   convertToDto(data: unknown): UserDto {
-    const transactionData = validateUserSchema.parse(data)
+    const transactionData = UserDtoSchema.parse(data)
 
     return {
       id: transactionData.id,

--- a/packages/types/src/entities/transactions/transaction.dto.ts
+++ b/packages/types/src/entities/transactions/transaction.dto.ts
@@ -1,13 +1,16 @@
-import type { TransactionCategoryEnum } from "~/enums/transaction-category.enum"
+import { z } from "zod"
 import { TransactionTypeEnum } from "~/enums/transaction-type.enum"
+import { IncomeCategoryEnum, ExpenseCategoryEnum } from "~/enums/transaction-category.enum"
 
-export type TransactionDto = {
-  id: number
-  userId: number
-  description: string
-  type: TransactionTypeEnum
-  category: TransactionCategoryEnum
-  amount: number
-  createdAt: Date
-  updatedAt: Date
-}
+export const TransactionDtoSchema = z.object({
+  id: z.number(),
+  userId: z.number(),
+  description: z.string(),
+  type: z.nativeEnum(TransactionTypeEnum),
+  category: z.union([z.nativeEnum(IncomeCategoryEnum), z.nativeEnum(ExpenseCategoryEnum)]),
+  amount: z.number(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export type TransactionDto = z.infer<typeof TransactionDtoSchema>

--- a/packages/types/src/entities/users/user-create.dto.ts
+++ b/packages/types/src/entities/users/user-create.dto.ts
@@ -1,3 +1,6 @@
-import type { UserDto } from "../users/user.dto"
+import { z } from "zod"
+import { UserDtoSchema } from "./user.dto"
 
-export type UserCreateDto = Pick<UserDto, "username" | "password">
+export const UserCreateDtoSchema = UserDtoSchema.pick({ username: true, password: true })
+
+export type UserCreateDto = z.infer<typeof UserCreateDtoSchema>

--- a/packages/types/src/entities/users/user-update.dto.ts
+++ b/packages/types/src/entities/users/user-update.dto.ts
@@ -1,3 +1,6 @@
-import type { UserDto } from "./user.dto"
+import { z } from "zod"
+import { UserDtoSchema } from "./user.dto"
 
-export type UserUpdateDto = Partial<UserDto>
+export const UserUpdateDtoSchema = UserDtoSchema.partial()
+
+export type UserUpdateDto = z.infer<typeof UserUpdateDtoSchema>

--- a/packages/types/src/entities/users/user.dto.ts
+++ b/packages/types/src/entities/users/user.dto.ts
@@ -1,7 +1,11 @@
-export type UserDto = {
-  id: number
-  username: string
-  password: string
-  profile_picture: string
-  createdAt: Date
-}
+import { z } from "zod"
+
+export const UserDtoSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  password: z.string(),
+  profile_picture: z.string(),
+  createdAt: z.date(),
+})
+
+export type UserDto = z.infer<typeof UserDtoSchema>


### PR DESCRIPTION
## Describe your changes
- refactor to use zod schemas for validation & TypeScript types

### Why?
Zod schemas help us achieve a [single source of truth](https://www.reddit.com/r/typescript/comments/10f8kah/is_using_zod_as_the_primary_source_of_truth_for/) with our TypeScript types and runtime validation.

This helps us reduce code duplication when we write frontend & backend code like with [`validateTransactionSchema`](https://github.com/0-BSCode/Budgeteer/blob/47a19e5e32d008a66b78a4f6d8913b1af91c06a5/packages/server/src/infrastructure/drizzle-data-service/repositories/transaction.repository.ts#L15) or [`validateUserSchema`](https://github.com/0-BSCode/Budgeteer/blob/47a19e5e32d008a66b78a4f6d8913b1af91c06a5/packages/server/src/infrastructure/drizzle-data-service/repositories/user.repository.ts#L7C7-L7C26), which is currently isolated in the backend.

With zod, we can simply reduce these validators + the TypeScript types into a single zod schema:

```ts
import { z } from "zod"

export const UserDtoSchema = z.object({
  id: z.number(),
  username: z.string(),
  password: z.string(),
  profile_picture: z.string(),
  createdAt: z.date(),
})

export type UserDto = z.infer<typeof UserDtoSchema>
```

> [!NOTE]
> This is reusable in both the frontend and backend, like when the frontend needs to do input validation for an incoming response. They no longer need to define their own validator and types.

## Checklist before requesting a review

- [x] I have performed a self-review of my code