### PR TITLE
[MISC] Abbreviate longer numbers when formatting value in dashboard

### DIFF
--- a/packages/client/src/features/dashboard/components/charts/net-income-chart.tsx
+++ b/packages/client/src/features/dashboard/components/charts/net-income-chart.tsx
@@ -10,6 +10,7 @@ import { TimeRangeEnum, TimeRangeEnumSchema } from "~/types/enums/TimeRangeEnum"
 import { groupTransactionsByTimeRange } from "../../lib/group-transactions-by-time-range"
 import dayjs from "dayjs"
 import { cn } from "~/lib/utils"
+import { formatValueWithPeso } from "~/features/transaction/lib/format-value-with-peso"
 
 const chartConfig = {
   desktop: {
@@ -108,11 +109,12 @@ export function NetIncomeChart({ timeRange }: Props) {
             >
               {isTrendingUp ? (
                 <>
-                  Trending up by {trend.toFixed(1)}% <TrendingUp className="h-4 w-4" />
+                  Trending up by {formatValueWithPeso(Number(trend.toFixed(1)))}% <TrendingUp className="h-4 w-4" />
                 </>
               ) : (
                 <>
-                  Trending down by {Math.abs(trend).toFixed(1)}% <TrendingDown className="h-4 w-4" />
+                  Trending down by {formatValueWithPeso(Number(Math.abs(trend).toFixed(1)))}%{" "}
+                  <TrendingDown className="h-4 w-4" />
                 </>
               )}
             </div>

--- a/packages/client/src/features/dashboard/components/transactions/transaction-item.tsx
+++ b/packages/client/src/features/dashboard/components/transactions/transaction-item.tsx
@@ -20,7 +20,7 @@ export function TransactionItem({ id, type, description, category, value }: Prop
     <Card className="mb-2 rounded-md p-4 transition-colors hover:bg-muted">
       <Link href={`/transaction/${id}`} className="flex w-full items-center justify-between gap-4 px-1">
         <div className="flex items-center gap-4">
-          <div className="flex max-w-[15ch] flex-col truncate lg:max-w-64">
+          <div className="flex max-w-[15ch] flex-col truncate lg:max-w-56">
             <p className="truncate font-semibold text-foreground">{convertToTitleCase(description)}</p>
             <p className="hidden truncate text-xs font-normal text-muted-foreground lg:block">{category}</p>
             {category.split("•").map((category, index) => (
@@ -30,7 +30,9 @@ export function TransactionItem({ id, type, description, category, value }: Prop
             ))}
           </div>
         </div>
-        <p className="text-base font-bold text-foreground lg:text-2xl">{formatValueWithPeso(value, transactionType)}</p>
+        <p className="line-clamp-1 text-base font-bold text-foreground lg:text-2xl">
+          {formatValueWithPeso(value, transactionType)}
+        </p>
       </Link>
     </Card>
   )

--- a/packages/client/src/features/transaction/lib/format-value-with-peso.ts
+++ b/packages/client/src/features/transaction/lib/format-value-with-peso.ts
@@ -1,6 +1,8 @@
 import { TransactionTypeEnum, TransactionTypeEnumSchema } from "@budgeteer/types"
 
 function abbreviateLargeNumbers(number: number) {
+  if (number < 10000) return number
+
   if (number > Number.MAX_SAFE_INTEGER) return number.toExponential()
   // Use the toLocaleString method to add suffixes to the number
   return number.toLocaleString("en-US", {
@@ -14,13 +16,11 @@ function abbreviateLargeNumbers(number: number) {
 }
 
 export function formatValueWithPeso(value: number, type?: TransactionTypeEnum): string {
-  let absoluteValue = Math.abs(value).toFixed(2)
+  const absoluteValue = abbreviateLargeNumbers(Number(Math.abs(value).toFixed(2)))
 
   if (!type) {
     return value < 0 ? `- ₱${absoluteValue}` : `₱${absoluteValue}`
   } else {
-    if (value >= 1000000) absoluteValue = abbreviateLargeNumbers(Number(absoluteValue))
-
     return type === TransactionTypeEnumSchema.Values.EXPENSE ? `- ₱${absoluteValue}` : `₱${absoluteValue}`
   }
 }


### PR DESCRIPTION
## Describe your changes
- Truncate transaction card amount on smaller screens
- Apply the same helper function to net income chart and stat cards in the dashboard

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshot or Screen recording of updated behavior
![image](https://github.com/user-attachments/assets/d8645517-45d8-4e2c-9485-d64f1f83630b)
